### PR TITLE
Feature/7 generate filename

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module stashbox
 go 1.14
 
 require (
+	github.com/PuerkitoBio/goquery v1.5.1
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/securego/gosec/v2 v2.4.0 // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/PuerkitoBio/goquery v1.5.1 h1:PSPBGne8NIUWw+/7vFBV+kG2J/5MOjbzc7154OaKCSE=
+github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
+github.com/andybalholm/cascadia v1.1.0 h1:BuuO6sSfQNFRu1LppgbD25Hr2vLYW25JvxHs5zzsLTo=
+github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -47,9 +51,11 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200927032502-5d4f70055728 h1:5wtQIAulKU5AbLQOkjxl32UufnIOqgBX72pS0AV14H0=

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -55,7 +55,13 @@ func (c *Crawler) Save() error {
 
 		// get current time
 		t := time.Now()
-		dateTime := fmt.Sprintf("%d-%02d-%02dT%02d:%02d:%02d",
+		var timestamp string
+		if runtime.GOOS == "windows" {
+			timestamp = "%d-%02d-%02dT%02d_%02d_%02d" // use underscores instead of colons
+		} else {
+			timestamp = "%d-%02d-%02dT%02d:%02d:%02d"
+		}
+		dateTime := fmt.Sprintf(timestamp,
 			t.Year(), t.Month(), t.Day(),
 			t.Hour(), t.Minute(), t.Second())
 

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -113,7 +113,7 @@ func createSiteFilename(url string, htmlBody []byte) (string, error) {
 	// Fix if filename is invalid
 	if runtime.GOOS == "windows" { // is windows
 		for _, ch := range forbiddenCharactersWindows {
-			title = strings.ReplaceAll(title, string(ch), "")
+			title = strings.ReplaceAll(title, string(ch), "_")
 		}
 		for _, name := range reservedFilenamesWindows {
 			if title == name { // wrap title with quotes
@@ -122,7 +122,7 @@ func createSiteFilename(url string, htmlBody []byte) (string, error) {
 		}
 	} else { // is unix
 		for _, ch := range forbiddenCharactersUnix {
-			title = strings.ReplaceAll(title, string(ch), "")
+			title = strings.ReplaceAll(title, string(ch), "_")
 		}
 	}
 	return title, nil

--- a/pkg/crawler/crawler_test.go
+++ b/pkg/crawler/crawler_test.go
@@ -1,7 +1,26 @@
 package crawler
 
-import "testing"
+import (
+	"net/http"
+	"testing"
+)
 
-func TestDummy(t* testing.T) {
+func TestDummy(t *testing.T) {
 
+}
+
+func TestGetHtmlTitle(t *testing.T) {
+	const url = "https://github.com/zpeters/stashbox"
+	const want = "GitHub - zpeters/stashbox: Your personal Internet Archive"
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	title, err := getHtmlTitle(resp)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if title != want {
+		t.Errorf("Wrong title found. Want: %s, Got : %s", want, title)
+	}
 }

--- a/pkg/crawler/crawler_test.go
+++ b/pkg/crawler/crawler_test.go
@@ -1,7 +1,6 @@
 package crawler
 
 import (
-	"net/http"
 	"testing"
 )
 
@@ -12,11 +11,11 @@ func TestDummy(t *testing.T) {
 func TestGetHtmlTitle(t *testing.T) {
 	const url = "https://github.com/zpeters/stashbox"
 	const want = "GitHub - zpeters/stashbox: Your personal Internet Archive"
-	resp, err := http.Get(url)
+	body, err := getHtmlBody(url)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	title, err := getHtmlTitle(resp)
+	title, err := getHtmlTitle(body)
 	if err != nil {
 		t.Errorf(err.Error())
 	}


### PR DESCRIPTION
# Description

Do #7. Create filenames for the `.html` and `.txt` generated files using the <title> tag of the webpage. 
- If <title> tag isn't present, do old way of using a hash of the url (that shouldn't happen a lot)
- If illegal characters are present in the <title> tag, replace them with an underscore, as suggested by @sharadbhat
- Also fixes #30, replacing colons by underscores if in windows

Notes:

- Using `runtime.GOOS` as criteria for illegal characters in the filesystem, don't know if there is a better way
- Followed [this](https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names) to find out illegal characters and reserved filenames

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Created a test function for `getHtmlTitle`. Was gonna do also a test for the `createSiteFilename` function which I implemented, but the result is dependent of the platform, so I didn't 

**Suggestions**
A few suggestions of mine for better collaborate coding in Go:
- As suggested by [Effective Go](https://golang.org/doc/effective_go.html), acronyms should be all uppercase, so `getHtmlBody` should actually be `getHTMLBody`
- Exported functions should have comments specifying them, also suggested by Effective Go
- Use this kind of template for PR's, it is a much better way of documenting the changes the repo passes through

You are obviously free to disagree with my suggestions, only trying to help :D
