### PR TITLE
Add  Pull requests template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,22 @@
+# Description
+
+Brief description of the pull request
+
+Notes:
+
+ - note a
+ - note b
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## How Has This Been Tested?
+
+Short sumary of how you have tested the changes
+
+### Suggestions
+(optional)


### PR DESCRIPTION
# Description

This PR creates a GitHub template for new web pull-requests.

Solves issue #32

Notes:

 - based on @lucasturci proposal from #31

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Tested using githubcli, wichs picks the template as expected

### Suggestions
We can create more than one template, for example, "bugfix", "new feature", "documentation", etc






