### PR TITLE
Address issue #36: add sanity checks for the URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 coverage.txt
+
+stashDb/

--- a/cmd/stashbox/main.go
+++ b/cmd/stashbox/main.go
@@ -46,7 +46,11 @@ func main() {
 			panic(err)
 		}
 
-		c.AddUrl(u)
+		err = c.AddUrl(u)
+		if err != nil {
+			panic(err)
+		}
+
 		err = c.Crawl()
 		if err != nil {
 			panic(err)

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"jaytaylor.com/html2text"
 )
 
+// Site ...
 type Site struct {
 	HtmlBody []byte
 	TextBody []byte
@@ -27,6 +29,7 @@ type Site struct {
 	Title    string
 }
 
+// Crawler ...
 type Crawler struct {
 	Urls    []string
 	Archive string
@@ -36,32 +39,43 @@ type Crawler struct {
 // Error Messages
 var (
 	errNoTitleInHtml = errors.New("No title tag in HTML response")
+	// regular expression from: https://mathiasbynens.be/demo/url-regex,
+	// by @imme_emosol
+	urlRegExp, _ = regexp.Compile("^(https|http)://(-\\.)?([^\\s/?\\.#-]+\\.?)+(/[^\\s]*)?$")
 )
 
+// NewCrawler ...
 func NewCrawler(archive string) (Crawler, error) {
 	return Crawler{
 		Archive: archive,
 	}, nil
 }
 
+// Save ...
 func (c *Crawler) Save() error {
 	ensureArchive(c.Archive)
+
+	// save all sites one by one
 	for _, s := range c.Sites {
 		fmt.Printf("Saving %s...\n", s.Url)
+
 		parsed, err := url.Parse(s.Url)
 		if err != nil {
 			return err
 		}
+
 		d := parsed.Host
 
 		// get current time
 		t := time.Now()
 		var timestamp string
+
 		if runtime.GOOS == "windows" {
 			timestamp = "%d-%02d-%02dT%02d_%02d_%02d" // use underscores instead of colons
 		} else {
 			timestamp = "%d-%02d-%02dT%02d:%02d:%02d"
 		}
+
 		dateTime := fmt.Sprintf(timestamp,
 			t.Year(), t.Month(), t.Day(),
 			t.Hour(), t.Minute(), t.Second())
@@ -96,11 +110,28 @@ func (c *Crawler) Save() error {
 			return err
 		}
 	}
+
 	return nil
 }
 
-func (c *Crawler) AddUrl(url string) {
+// AddUrl ...
+func (c *Crawler) AddUrl(url string) error {
+	url = strings.TrimSpace(url)
+	if len(url) == 0 {
+		return errors.New("URL can't be empty or only containing space")
+	}
+
+	if !strings.Contains(url, "://") {
+		url = "http://" + url
+	}
+
+	if !urlRegExp.MatchString(url) {
+		return errors.New("Illegal url:" + url)
+	}
+
 	c.Urls = append(c.Urls, url)
+
+	return nil
 }
 
 // create filename using site title
@@ -142,6 +173,7 @@ func createSiteFilename(url string, htmlBody []byte) (string, error) {
 	return title, nil
 }
 
+// Crawl ...
 func (c *Crawler) Crawl() error {
 	for _, u := range c.Urls {
 		fmt.Printf("Crawling %s...\n", u)
@@ -157,18 +189,20 @@ func (c *Crawler) Crawl() error {
 		if err != nil {
 			return err
 		}
+
 		site.Title = title
 
 		textBody, err := getTextBody(htmlBody)
 		if err != nil {
 			return err
 		}
-		site.TextBody = textBody
 
+		site.TextBody = textBody
 		site.Url = u
 
 		c.Sites = append(c.Sites, site)
 	}
+
 	return nil
 }
 
@@ -197,6 +231,7 @@ func getHtmlBody(url string) (body []byte, err error) {
 	if err != nil {
 		return body, err
 	}
+
 	defer resp.Body.Close()
 
 	htmlBody, err := ioutil.ReadAll(resp.Body)

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -41,7 +41,7 @@ var (
 	errNoTitleInHtml = errors.New("No title tag in HTML response")
 	// regular expression from: https://mathiasbynens.be/demo/url-regex,
 	// by @imme_emosol
-	urlRegExp, _ = regexp.Compile("^(https|http)://(-\\.)?([^\\s/?\\.#-]+\\.?)+(/[^\\s]*)?$")
+	urlRegExp, _ = regexp.Compile(`^(https|http)://(-\.)?([^\s/?\.#-]+\.?)+(/[^\s]*)?$`)
 )
 
 // NewCrawler ...

--- a/pkg/crawler/crawler_test.go
+++ b/pkg/crawler/crawler_test.go
@@ -1,6 +1,7 @@
 package crawler
 
 import (
+	"strconv"
 	"testing"
 )
 
@@ -28,6 +29,7 @@ func TestGetHtmlTitle(t *testing.T) {
 }
 
 func TestAddUrl(t *testing.T) {
+	count := 0
 	c, err := NewCrawler("")
 	if err != nil {
 		t.Errorf("Unable to create crawler:" + err.Error())
@@ -35,12 +37,14 @@ func TestAddUrl(t *testing.T) {
 
 	url := "https://www.github.com"
 	err = c.AddUrl(url)
+	count++
 	if err != nil {
 		t.Errorf("Test case for url: '" + url + "' failed; it should pass; error:" + err.Error())
 	}
 
 	url = "http://www.github.com:8000/"
 	err = c.AddUrl(url)
+	count++
 	if err != nil {
 		t.Errorf("Test case for url: '" + url + "' failed; it should pass; error:" + err.Error())
 	}
@@ -65,7 +69,12 @@ func TestAddUrl(t *testing.T) {
 
 	url = "www.github.com:8000/"
 	err = c.AddUrl(url)
+	count++
 	if err != nil {
 		t.Errorf("Test case for url: '" + url + "' failed; it should pass; error:" + err.Error())
+	}
+
+	if len(c.Urls) != count {
+		t.Errorf("There should be " + strconv.Itoa(count) + " entries, found:" + strconv.Itoa(len(c.Urls)))
 	}
 }

--- a/pkg/crawler/crawler_test.go
+++ b/pkg/crawler/crawler_test.go
@@ -11,15 +11,61 @@ func TestDummy(t *testing.T) {
 func TestGetHtmlTitle(t *testing.T) {
 	const url = "https://github.com/zpeters/stashbox"
 	const want = "GitHub - zpeters/stashbox: Your personal Internet Archive"
+
 	body, err := getHtmlBody(url)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
+
 	title, err := getHtmlTitle(body)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
+
 	if title != want {
 		t.Errorf("Wrong title found. Want: %s, Got : %s", want, title)
+	}
+}
+
+func TestAddUrl(t *testing.T) {
+	c, err := NewCrawler("")
+	if err != nil {
+		t.Errorf("Unable to create crawler:" + err.Error())
+	}
+
+	url := "https://www.github.com"
+	err = c.AddUrl(url)
+	if err != nil {
+		t.Errorf("Test case for url: '" + url + "' failed; it should pass; error:" + err.Error())
+	}
+
+	url = "http://www.github.com:8000/"
+	err = c.AddUrl(url)
+	if err != nil {
+		t.Errorf("Test case for url: '" + url + "' failed; it should pass; error:" + err.Error())
+	}
+
+	url = "httpd://www.github.com"
+	err = c.AddUrl(url)
+	if err == nil {
+		t.Errorf("Test case for url: '" + url + "' failed; it should fail, but we got no error")
+	}
+
+	url = "https:///www.github.com"
+	err = c.AddUrl(url)
+	if err == nil {
+		t.Errorf("Test case for url: '" + url + "' failed; it should fail, but we got no error")
+	}
+
+	url = "//www.github.com:8000"
+	err = c.AddUrl(url)
+	if err == nil {
+		t.Errorf("Test case for url: '" + url + "' failed; it should fail, but we got no error")
+	}
+
+	url = "www.github.com:8000/"
+	err = c.AddUrl(url)
+	if err != nil {
+		t.Errorf("Test case for url: '" + url + "' failed; it should pass; error:" + err.Error())
 	}
 }


### PR DESCRIPTION
This PR will try to address issue #36, where we can use some sanity checks before adding URLs from the command line to crawl against.

We won't go overly restricted in this updates, but use a regular expression as introduced in https://mathiasbynens.be/demo/url-regex, by @imme_emosol. As shown in the source website, the chosen regular expression is not terribly complex, yet cover a fair wide range of legal and illegal cases. We will make small tweaks here to only accept `http` and `https` protocols, as they're the ones accepted by the underlying `http` package.

In addition, we will create some simple tests to verify if the sanity checks would work as expected.

We will also update the command line program to display the errors if the URLs are rejected.

Please let me know if you have any questions or suggestions.

Cheers!