### PR TITLE
Closes #23 : Concurreny crawling and input support for multiple websites 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 coverage.txt
+
+stashDb/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # stashbox
+
 [![Go Report Card](https://goreportcard.com/badge/github.com/zpeters/stashbox)](https://goreportcard.com/report/github.com/zpeters/stashbox)
 [![Build Status](https://travis-ci.org/zpeters/stashbox.svg?branch=main)](https://travis-ci.org/zpeters/stashbox)
 ![Run Gosec](https://github.com/zpeters/stashbox/workflows/Run%20Gosec/badge.svg?branch=main)
@@ -9,7 +10,7 @@
 
 ## Stashbox is your personal Internet Archive
 
-The goal of stashbox is to help you create your own - personal copy of websites that you wish to archive.  
+The goal of stashbox is to help you create your own - personal copy of websites that you wish to archive.
 
 The initial way to do this will be to run a simple command, but in the future it can be extended to a web interface, a plugin or other means.
 
@@ -17,22 +18,42 @@ Having a local "static" copy of a website can help for research, change tracking
 
 ## Roadmap
 
-- [x]  Initial command line client to add urls to a personal archive with Text, Html and Pdf copies of the website
-- [x]  Ability to save new versions of the same URL
-- [ ]  Version "diffing" and browsing
-- [ ]  User friendly interface (web, etc)
-- [ ]  Searching and other functions
+- [x] Initial command line client to add urls to a personal archive with Text, Html and Pdf copies of the website
+- [x] Ability to save new versions of the same URL
+- [ ] Version "diffing" and browsing
+- [ ] User friendly interface (web, etc)
+- [ ] Searching and other functions
 
-## Usage
+## Usage flags
+
 ```
 Usage of ./stashbox:
   -b string
     	folder to save stash into (default "./stashDb")
+  -crawl
+    	crawl and save websites
   -list
     	list saved archives
-  -url string
-    	url to download
 ```
+
+## Instructions for usage
+
+1. Build the binary with name preferably stashbox
+1. You can give path to the stash folder using `-b` flag else it will default to ./stashDb
+1. Do `./stashbox -list` to get list of saved websites
+1. To save a single or multiple websites you have 2 options to provide the inputs
+
+- Run `./stashbox -crawl` and then provide number of websites and the urls of the websites to save as command line inputs
+- Create a urls.txt file with following structure and feed it to the binary like `./stashbox -crawl < urls.txt`
+  ```
+  5
+  https://www.site1.com
+  https://www.site2.com
+  https://www.site3.com
+  https://www.site4.com
+  https://www.site5.com
+  ```
+
 ## Contributing
 
-New issues and pull requests are welcomed.  Please see [CONTRIBUTING.md](CONTRIBUTING.md)
+New issues and pull requests are welcomed. Please see [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/cmd/stashbox/main.go
+++ b/cmd/stashbox/main.go
@@ -1,28 +1,25 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"os"
 	"stashbox/pkg/archive"
 	"stashbox/pkg/crawler"
+	"sync"
 )
 
-var u string
+var crawl bool
 var basePath string
 var listFlag bool
 
 func main() {
 	// get flags
-	flag.StringVar(&u, "url", "", "url to download")
+	flag.BoolVar(&crawl, "crawl", false, "crawl and save websites")
 	flag.StringVar(&basePath, "b", "./stashDb", "folder to save stash into")
 	flag.BoolVar(&listFlag, "list", false, "list saved archives")
 	flag.Parse()
-
-	if len(os.Args) == 1 {
-		flag.Usage()
-		os.Exit(0)
-	}
 
 	if listFlag {
 		archives, err := archive.GetArchives(basePath)
@@ -40,21 +37,58 @@ func main() {
 		os.Exit(0)
 	}
 
-	if u != "" {
-		c, err := crawler.NewCrawler(basePath)
-		if err != nil {
-			panic(err)
+	if crawl {
+		var n int
+		var urls []string
+		scanner := bufio.NewScanner(os.Stdin)
+
+		// inputs
+		fmt.Println("Enter number of urls: ")
+		fmt.Scan(&n)
+		fmt.Println("Enter the urls: ")
+		for i := 0; i < n; i++ {
+			scanner.Scan()
+			text := scanner.Text()
+			if len(text) != 0 {
+				urls = append(urls, text)
+			} else {
+				break
+			}
 		}
 
-		c.AddUrl(u)
-		err = c.Crawl()
-		if err != nil {
-			panic(err)
+		// spin goroutine for each url 
+		var wg sync.WaitGroup
+		wg.Add(len(urls))
+		for _, url := range urls {
+			go crawlUtil(url, &wg)
 		}
+		wg.Wait()
+	} else {
+		flag.Usage()
+		os.Exit(0)
 
-		err = c.Save()
-		if err != nil {
-			panic(err)
-		}
+	}
+}
+
+func crawlUtil(url string, wg *sync.WaitGroup) {
+	defer wg.Done()
+	c, err := crawler.NewCrawler(basePath)
+	if err != nil {
+		panic(err)
+	}
+
+	c.AddUrl(url)
+	err = c.Crawl()
+	if err != nil {
+		fmt.Printf("\nError : %s\n", url)
+		fmt.Print(err)
+		return
+	}
+
+	err = c.Save()
+	if err != nil {
+		fmt.Printf("\nError : %s\n", url)
+		fmt.Print(err)
+		return
 	}
 }

--- a/pkg/crawler/crawler_test.go
+++ b/pkg/crawler/crawler_test.go
@@ -1,6 +1,7 @@
 package crawler
 
 import (
+	"strconv"
 	"testing"
 )
 
@@ -11,15 +12,69 @@ func TestDummy(t *testing.T) {
 func TestGetHtmlTitle(t *testing.T) {
 	const url = "https://github.com/zpeters/stashbox"
 	const want = "GitHub - zpeters/stashbox: Your personal Internet Archive"
+
 	body, err := getHtmlBody(url)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
+
 	title, err := getHtmlTitle(body)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
+
 	if title != want {
 		t.Errorf("Wrong title found. Want: %s, Got : %s", want, title)
+	}
+}
+
+func TestAddUrl(t *testing.T) {
+	count := 0
+	c, err := NewCrawler("")
+	if err != nil {
+		t.Errorf("Unable to create crawler:" + err.Error())
+	}
+
+	url := "https://www.github.com"
+	err = c.AddUrl(url)
+	count++
+	if err != nil {
+		t.Errorf("Test case for url: '" + url + "' failed; it should pass; error:" + err.Error())
+	}
+
+	url = "http://www.github.com:8000/"
+	err = c.AddUrl(url)
+	count++
+	if err != nil {
+		t.Errorf("Test case for url: '" + url + "' failed; it should pass; error:" + err.Error())
+	}
+
+	url = "httpd://www.github.com"
+	err = c.AddUrl(url)
+	if err == nil {
+		t.Errorf("Test case for url: '" + url + "' failed; it should fail, but we got no error")
+	}
+
+	url = "https:///www.github.com"
+	err = c.AddUrl(url)
+	if err == nil {
+		t.Errorf("Test case for url: '" + url + "' failed; it should fail, but we got no error")
+	}
+
+	url = "//www.github.com:8000"
+	err = c.AddUrl(url)
+	if err == nil {
+		t.Errorf("Test case for url: '" + url + "' failed; it should fail, but we got no error")
+	}
+
+	url = "www.github.com:8000/"
+	err = c.AddUrl(url)
+	count++
+	if err != nil {
+		t.Errorf("Test case for url: '" + url + "' failed; it should pass; error:" + err.Error())
+	}
+
+	if len(c.Urls) != count {
+		t.Errorf("There should be " + strconv.Itoa(count) + " entries, found:" + strconv.Itoa(len(c.Urls)))
 	}
 }


### PR DESCRIPTION
This pull request adds support for 

- Taking multiple URLs at the same time either through command line input or through a text file.
- Adding goroutines support to crawl multiple websites concurrently.

The old option `-u` was removed as it was able to take one URL at a time and a new option of `-crawl` was added.
So now if we want to crawl multiple websites we have to provide the `-crawl` option and then provide the number of websites and their URLs through the command line inputs or write a urls.txt (name doesn't matter) with the following format :
```
<number_of_websites>
url1
url2
.
.
```


