### PR TITLE
Support for multiple inputs and concurrent crawling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,30 @@ Having a local "static" copy of a website can help for research, change tracking
 Usage of ./stashbox:
   -b string
     	folder to save stash into (default "./stashDb")
+  -crawl
+    	crawl and save websites
   -list
     	list saved archives
-  -url string
-    	url to download
 ```
+
+## Instructions for usage
+
+1. Build the binary with name preferably stashbox
+1. You can give path to the stash folder using `-b` flag else it will default to ./stashDb
+1. Do `./stashbox -list` to get list of saved websites
+1. To save a single or multiple websites you have 2 options to provide the inputs
+
+- Run `./stashbox -crawl` and then provide number of websites and the urls of the websites to save as command line inputs
+- Create a urls.txt file with following structure and feed it to the binary like `./stashbox -crawl < urls.txt`
+  ```
+  5
+  https://www.site1.com
+  https://www.site2.com
+  https://www.site3.com
+  https://www.site4.com
+  https://www.site5.com
+  ```
+
 ## Contributing
 
 New issues and pull requests are welcomed.  Please see [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/cmd/stashbox/main.go
+++ b/cmd/stashbox/main.go
@@ -1,28 +1,25 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"os"
 	"stashbox/pkg/archive"
 	"stashbox/pkg/crawler"
+	"sync"
 )
 
-var u string
+var crawl bool
 var basePath string
 var listFlag bool
 
 func main() {
 	// get flags
-	flag.StringVar(&u, "url", "", "url to download")
+	flag.BoolVar(&crawl, "crawl", false, "crawl and save websites")
 	flag.StringVar(&basePath, "b", "./stashDb", "folder to save stash into")
 	flag.BoolVar(&listFlag, "list", false, "list saved archives")
 	flag.Parse()
-
-	if len(os.Args) == 1 {
-		flag.Usage()
-		os.Exit(0)
-	}
 
 	if listFlag {
 		archives, err := archive.GetArchives(basePath)
@@ -40,25 +37,67 @@ func main() {
 		os.Exit(0)
 	}
 
-	if u != "" {
-		c, err := crawler.NewCrawler(basePath)
+	if crawl {
+		var n int
+		var urls []string
+		scanner := bufio.NewScanner(os.Stdin)
+
+		// inputs
+		fmt.Println("Enter number of urls: ")
+		_, err := fmt.Scan(&n)
 		if err != nil {
 			panic(err)
+		}
+		fmt.Println("Enter the urls: ")
+		for i := 0; i < n; i++ {
+			scanner.Scan()
+			text := scanner.Text()
+			if len(text) != 0 {
+				urls = append(urls, text)
+			} else {
+				break
+			}
 		}
 
-		err = c.AddUrl(u)
-		if err != nil {
-			panic(err)
+		// spin goroutine for each url
+		var wg sync.WaitGroup
+		wg.Add(len(urls))
+		for _, url := range urls {
+			go crawlUtil(url, &wg)
 		}
+		wg.Wait()
+	} else {
+		flag.Usage()
+		os.Exit(0)
 
-		err = c.Crawl()
-		if err != nil {
-			panic(err)
-		}
+	}
+}
 
-		err = c.Save()
-		if err != nil {
-			panic(err)
-		}
+func crawlUtil(url string, wg *sync.WaitGroup) {
+	defer wg.Done()
+	c, err := crawler.NewCrawler(basePath)
+	if err != nil {
+		panic(err)
+	}
+
+	err = c.AddUrl(url)
+	if err != nil {
+		fmt.Printf("\nError : %s\n", url)
+		fmt.Print(err)
+		return
+	}
+
+	err = c.Crawl()
+	if err != nil {
+		fmt.Printf("\nError : %s\n", url)
+		fmt.Print(err)
+		return
+	}
+
+	err = c.Save()
+	if err != nil {
+		fmt.Printf("\nError : %s\n", url)
+		fmt.Print(err)
+		return
 	}
 }


### PR DESCRIPTION
Closes #23
This pull request adds support for 

- Taking multiple URLs at the same time either through command line input or through a text file.
- Adding goroutines support to crawl multiple websites concurrently.

The old option `-u` was removed as it was able to take one URL at a time and a new option of `-crawl` was added.
So now if we want to crawl multiple websites we have to provide the `-crawl` option and then provide the number of websites and their URLs through the command line inputs or write a urls.txt (name doesn't matter) with the following format :
```
<number_of_websites>
url1
url2
.
.
```

Also, now the errors returned in the main function will be printed on the console and the goroutine will be exited instead of panic with aborting the whole program and other crawlers. 

A screenshot on 2 ways to take inputs :
![Screenshot from 2020-10-03 21-00-28](https://user-images.githubusercontent.com/43640923/94995401-a75f5c80-05bb-11eb-8b77-9b121b47c072.png)

