### PR TITLE
When n isn't specified, bring up a prompt instead of an error message

### DIFF
--- a/cmd/stashbox/main.go
+++ b/cmd/stashbox/main.go
@@ -96,14 +96,23 @@ func main() {
 			openCmd.Usage()
 			os.Exit(2)
 		}
-		if *n < 1 {
-			fmt.Println("Error: -n is required")
-			openCmd.Usage()
-			os.Exit(1)
-		}
 		archives, err := archive.GetArchives(*openBase)
 		if err != nil {
 			panic(err)
+		}
+
+		if *n < 1 {
+			fmt.Println("Choose an archive to open:")
+			for i, n := range archives {
+				fmt.Printf("%d. %s [%d image(s)]\n", i+1, n.URL, len(n.Dates))
+			}
+			fmt.Print("\n> ")
+			_, err := fmt.Scanf("%d", n)
+
+			if err != nil {
+				fmt.Printf("ERROR: reading input: %v", err)
+				os.Exit(1)
+			}
 		}
 
 		a := archives[*n-1]


### PR DESCRIPTION
To make stashbox a little nicer, instead of showing a usage message when n isn't specified, just show a list of the archives and all the user to specify the Archive # they want to open.