### PR TITLE
Fixed list command error when building the archives

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -2,7 +2,9 @@ package archive
 
 import (
 	"fmt"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/bmatcuk/doublestar/v2"
 )
@@ -32,26 +34,49 @@ func GetArchives(basePath string) (archives []Archive, err error) {
 }
 
 func buildArchives(path string, files []string) ([]Archive, error) {
-	var archives = []Archive{}
+	var archive *Archive
+	var dates []string
 	var pPage string
 	var page string
-	dates := make([]string, 0)
+
+	archives := []Archive{}
+	setOfArchives := make(map[*Archive]bool)
 	path += "/"
+
 	for _, file := range files {
 		pieces := strings.Split(strings.TrimPrefix(file, strings.TrimLeft(path, "./")), "/")
 		page = strings.Join(pieces[0:len(pieces)-1], "/")
 		date := strings.TrimRight(pieces[len(pieces)-1], ".pdf")
 
-		if page != pPage && pPage != "" {
+		if _, err := time.Parse("2006-02-01T15:04:05", date); err != nil {
 			return archives, fmt.Errorf("Error building archive")
+		}
+		if page != pPage {
+			dates = make([]string, 0)
+			archive = &Archive{URL: page}
 		}
 
 		dates = append(dates, date)
+		archive.Dates = dates
+
+		if _, present := setOfArchives[archive]; !present {
+			setOfArchives[archive] = true
+		}
+
 		pPage = page
+
 	}
 
-	a := Archive{page, dates}
-	archives = append(archives, a)
+	for key := range setOfArchives {
+		archives = append(archives, *key)
+	}
+
+	// Sort the archives because it is not sorted when using a map.
+	// Important for "open" command to make sure it is in the same
+	// order every time getArchives is called
+	sort.Slice(archives, func(i, j int) bool {
+		return archives[i].URL < archives[j].URL
+	})
 
 	return archives, nil
 }


### PR DESCRIPTION
Fixed some errors mentioned in #66 when using `list` command. The details are:

- When adding exact same path of same domain more than once, it will list only one item with more than 1 image description.
- When adding another path of same domain, it will listed as its own, not as another image of the same domain.
- It will now return error if the timestamp of the file is invalid.
- It will return the list sorted by lexicographical order of page URL for ease of use.

Example of output:
```
./stashbox add -u https://facebook.com
./stashbox add -u thehelpfulhacker.net
./stashbox add -u thehelpfulhacker.net/posts/2020-10-13-golang-testify-table-tests
./stashbox add -u thehelpfulhacker.net

./stashbox list
Archive listing...
1. facebook.com [1 image(s)]
2. thehelpfulhacker.net [2 image(s)]
3. thehelpfulhacker.net/posts/2020-10-13-golang-testify-table-tests [1 image(s)]
```